### PR TITLE
The .sf folder should be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .sfdx
+.sf
 .localdevserver
 .DS_Store
 node_modules

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-* @khawkins @AdamLiechty
+* @salesforce/offline-app-starter-kit-committers


### PR DESCRIPTION
This is another folder created by newer version of the Salesforce CLI, at project install. It contains configuration local to the user.