### PR TITLE
Fixing full name display in Contact edit when first name value is null

### DIFF
--- a/force-app/main/default/lwc/editContactRecord/__tests__/data/getRecord_firstNameNull.json
+++ b/force-app/main/default/lwc/editContactRecord/__tests__/data/getRecord_firstNameNull.json
@@ -1,0 +1,19 @@
+{
+    "fields": {
+        "Title": {
+            "value": "Contract Title"
+        },
+        "FirstName": {
+            "value": null
+        },
+        "LastName": {
+            "value": "Last"
+        },
+        "Phone": {
+            "value": "123-456-7890"
+        },
+        "Email": {
+            "value": "mock@test.fake"
+        }
+    }
+ }

--- a/force-app/main/default/lwc/editContactRecord/__tests__/editContactRecord.test.js
+++ b/force-app/main/default/lwc/editContactRecord/__tests__/editContactRecord.test.js
@@ -9,6 +9,7 @@ import PHONE_FIELD from '@salesforce/schema/Contact.Phone'
 import EMAIL_FIELD from '@salesforce/schema/Contact.Email'
 
 const mockRecord = require("./data/getRecord.json")
+const mockRecordFirstNameNull = require("./data/getRecord_firstNameNull.json")
 
 describe('c-edit-contact-record', () => {
     afterEach(() => {
@@ -69,6 +70,35 @@ describe('c-edit-contact-record', () => {
             const displayName = element.shadowRoot.querySelector('lightning-layout-item[data-id="name"]')
 
             const mockedName = mockRecord.fields.FirstName.value + ' ' + mockRecord.fields.LastName.value
+            
+            expect(displayName.innerHTML).toBe(mockedName)
+        })
+    })
+
+    it('should only display last name if first name is null', () => {
+        const RECORD_ID = "003abcdefghijklmno"
+        const OBJECT_API_NAME = 'Contact'
+
+        const element = createElement('c-edit-contact-record', {
+            is: EditContactRecord
+        })
+        document.body.appendChild(element)
+        element.recordId = RECORD_ID
+        element.objectApiName = OBJECT_API_NAME
+        document.body.appendChild(element)
+
+        // Emit mock record into the wired field - we have to do this after inserting into DOM 
+        // for the component to receive updates. We will need to use a promise next to wait for 
+        // DOM to re-render
+        getRecord.emit(mockRecordFirstNameNull)
+
+        // Resolve a promise to wait for a re-render of the new content to include the name value
+        // that is built after the @wire executes.
+        return Promise.resolve().then(() => {
+            const displayName = element.shadowRoot.querySelector('lightning-layout-item[data-id="name"]')
+
+            // Full name should only consist of last name
+            const mockedName = mockRecord.fields.LastName.value
             
             expect(displayName.innerHTML).toBe(mockedName)
         })

--- a/force-app/main/default/lwc/editContactRecord/editContactRecord.js
+++ b/force-app/main/default/lwc/editContactRecord/editContactRecord.js
@@ -26,13 +26,22 @@ export default class EditContactRecord extends LightningElement {
     record
 
     get fullName() {
-        var first = (this.record && this.record.data && this.record.data.fields && this.record.data.fields.FirstName) ?
-        (this.record.data.fields.FirstName.value + " ") : // append a space after first name
-        ""
-
-        var last = (this.record && this.record.data && this.record.data.fields && this.record.data.fields.LastName) ?
-        this.record.data.fields.LastName.value :
-        ""
+        var first =
+            this.record &&
+            this.record.data &&
+            this.record.data.fields &&
+            this.record.data.fields.FirstName &&
+            this.record.data.fields.FirstName.value
+                ? (this.record.data.fields.FirstName.value + " ") : // append a space after first name
+                ""
+        var last =
+            this.record &&
+            this.record.data &&
+            this.record.data.fields &&
+            this.record.data.fields.LastName &&
+            this.record.data.fields.LastName.value
+                ? this.record.data.fields.LastName.value :
+                ""
         return first + last
     }
 

--- a/force-app/main/default/lwc/editContactRecord/editContactRecord.js
+++ b/force-app/main/default/lwc/editContactRecord/editContactRecord.js
@@ -26,7 +26,7 @@ export default class EditContactRecord extends LightningElement {
     record
 
     get fullName() {
-        var first =
+        const first =
             this.record &&
             this.record.data &&
             this.record.data.fields &&
@@ -34,7 +34,7 @@ export default class EditContactRecord extends LightningElement {
             this.record.data.fields.FirstName.value
                 ? (this.record.data.fields.FirstName.value + " ") : // append a space after first name
                 ""
-        var last =
+        const last =
             this.record &&
             this.record.data &&
             this.record.data.fields &&

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js
@@ -2,6 +2,7 @@ import { LightningElement, api, wire } from 'lwc';
 import { getRecord } from 'lightning/uiRecordApi';
 
 import TITLE_FIELD from '@salesforce/schema/Contact.Title';
+import NAME_FIELD from '@salesforce/schema/Contact.Name';
 import FIRSTNAME_FIELD from '@salesforce/schema/Contact.FirstName';
 import LASTNAME_FIELD from '@salesforce/schema/Contact.LastName';
 import PHONE_FIELD from '@salesforce/schema/Contact.Phone';
@@ -9,6 +10,7 @@ import EMAIL_FIELD from '@salesforce/schema/Contact.Email';
 
 const FIELDS = [
     TITLE_FIELD,
+    NAME_FIELD,
     FIRSTNAME_FIELD,
     LASTNAME_FIELD,
     PHONE_FIELD,


### PR DESCRIPTION
Previously the display name below would be rendered as "null FNU". After the fix:
![Screenshot_1665095554](https://user-images.githubusercontent.com/20428467/194430624-0efb867b-f031-4403-90e1-e25c748bf6af.png)

Also fixing Name display in the Contact view
![Screenshot_1665095544](https://user-images.githubusercontent.com/20428467/194430616-4b422ca2-da06-4bcc-b5e6-fc9d5cfe5bbe.png)
