### PR TITLE
fix lex bug

### DIFF
--- a/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js
+++ b/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js
@@ -53,7 +53,7 @@ export default class ViewAccountRecord extends LightningElement {
   }
 
   get cardIconName() {
-    return "standard:" + this.objectApiName.toLowerCase();
+    return `standard:${this.objectApiName ? this.objectApiName.toLowerCase() : ''}`
   }
 
   get recordDataExists() {

--- a/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js
+++ b/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js
@@ -53,7 +53,9 @@ export default class ViewAccountRecord extends LightningElement {
   }
 
   get cardIconName() {
-    return `standard:${this.objectApiName ? this.objectApiName.toLowerCase() : ''}`
+    return `standard:${
+      this.objectApiName ? this.objectApiName.toLowerCase() : ""
+    }`;
   }
 
   get recordDataExists() {


### PR DESCRIPTION
This statement bombs the view quick action out in lex because the objectApiName is not available on first load. Fixing this can simplify debugging issues w/ starter kit