### PR TITLE
fix static analysis

### DIFF
--- a/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js
+++ b/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js
@@ -6,21 +6,15 @@ import WEBSITE_FIELD from "@salesforce/schema/Account.Website";
 import INDUSTRY_FIELD from "@salesforce/schema/Account.Industry";
 import TYPE_FIELD from "@salesforce/schema/Account.Type";
 
-const FIELDS = [
-  NAME_FIELD,
-  PHONE_FIELD,
-  WEBSITE_FIELD,
-  INDUSTRY_FIELD,
-  TYPE_FIELD,
-];
-
 export default class ViewAccountRecord extends LightningElement {
   @api recordId;
   @api objectApiName;
 
-  fields = FIELDS;
+  get fields() {
+    return [NAME_FIELD, PHONE_FIELD, WEBSITE_FIELD, INDUSTRY_FIELD, TYPE_FIELD];
+  }
 
-  @wire(getRecord, { recordId: "$recordId", fields: FIELDS })
+  @wire(getRecord, { recordId: "$recordId", fields: "$fields" })
   record;
 
   get name() {


### PR DESCRIPTION
https://developer.salesforce.com/docs/atlas.en-us.mobile_offline.meta/mobile_offline/offline_static_analysis.htm

private properties can't be used in wires and breaks static analysis...these fields eventually need to be used in getRecordUi call within the form. komaci does support simple getters though so wrapping the fields in a getter should fix this. 

If you install komaci https://github.com/salesforce/komaci and build it, you can run the cli like `yarn komaci analyze` and see the error: 
```
error komaci1015: This child component references an unanalyzable property 'fields' that’s not a public property.
27                     <lightning-record-form record-id={recordId} object-api-name={objectApiName} fields={fields}
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
28                         columns="1" mode="view">
                           ~~~~~~~~~~~~~~~~~~~~~~~~
29                     </lightning-record-form>
                       ~~~~~~~~~~~~~~~~~~~~~~~~
```