### PR TITLE
Bump eslint plugin version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@salesforce/eslint-config-lwc": "^3.3.3",
         "@salesforce/eslint-plugin-aura": "^2.1.0",
         "@salesforce/eslint-plugin-lightning": "^1.0.0",
-        "@salesforce/eslint-plugin-lwc-graph-analyzer": "0.6.2",
+        "@salesforce/eslint-plugin-lwc-graph-analyzer": "^0.7.0",
         "@salesforce/sfdx-lwc-jest": "^1.1.3",
         "eslint": "^8.27.0",
         "eslint-config-prettier": "^8.5.0",
@@ -2328,9 +2328,9 @@
       }
     },
     "node_modules/@salesforce/eslint-plugin-lwc-graph-analyzer": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/eslint-plugin-lwc-graph-analyzer/-/eslint-plugin-lwc-graph-analyzer-0.6.2.tgz",
-      "integrity": "sha512-TNOSFqikIncP5Bno3KzOtBMDzHlVovgrcWi2w63lW8YTrMJg6Q750nClRruUBvkXwBatNxniMvMYB5Yn/JBshQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/eslint-plugin-lwc-graph-analyzer/-/eslint-plugin-lwc-graph-analyzer-0.7.0.tgz",
+      "integrity": "sha512-CJVogaOm5w+CpyhbIhaD0U69GPWf7yyyTPiBPD82DBl05gTGDiC82NH6xtL/HKC9XICcISdCimLiuDYL4ChCAA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.20.2",
@@ -10775,9 +10775,9 @@
       "requires": {}
     },
     "@salesforce/eslint-plugin-lwc-graph-analyzer": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/eslint-plugin-lwc-graph-analyzer/-/eslint-plugin-lwc-graph-analyzer-0.6.2.tgz",
-      "integrity": "sha512-TNOSFqikIncP5Bno3KzOtBMDzHlVovgrcWi2w63lW8YTrMJg6Q750nClRruUBvkXwBatNxniMvMYB5Yn/JBshQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/eslint-plugin-lwc-graph-analyzer/-/eslint-plugin-lwc-graph-analyzer-0.7.0.tgz",
+      "integrity": "sha512-CJVogaOm5w+CpyhbIhaD0U69GPWf7yyyTPiBPD82DBl05gTGDiC82NH6xtL/HKC9XICcISdCimLiuDYL4ChCAA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.20.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@salesforce/eslint-config-lwc": "^3.3.3",
     "@salesforce/eslint-plugin-aura": "^2.1.0",
     "@salesforce/eslint-plugin-lightning": "^1.0.0",
-    "@salesforce/eslint-plugin-lwc-graph-analyzer": "0.6.2",
+    "@salesforce/eslint-plugin-lwc-graph-analyzer": "^0.7.0",
     "@salesforce/sfdx-lwc-jest": "^1.1.3",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
Bumping version of `eslint-plugin-lwc-graph-analyzer`. This version includes all rules packages in the plugin as default recommended rules and should pick up more lint errors.