### PR TITLE
Refactored viewAccountRecord and created viewContactRecord and viewOpptyRecord.

### DIFF
--- a/force-app/main/default/lwc/draftDetailsList/__tests__/data/getRecord.json
+++ b/force-app/main/default/lwc/draftDetailsList/__tests__/data/getRecord.json
@@ -1,0 +1,36 @@
+{
+    "fields": {
+        "Name": {
+            "value": "Name Mock"
+        },
+        "Phone": {
+            "value": "123-456-7890"
+        },
+        "Website": {
+            "value": "www.mocksite.fake"
+        },
+        "Owner.Name": {
+            "value": "Owner name"
+        },
+        "Industry": {
+            "value": "Industry mock"
+        },
+        "Type": {
+            "value": "Record type"
+        }
+    },
+
+    "drafts": {
+        "serverValues" : {
+            "Name" : {
+                "value" : "Old Name",
+                "displayValue" : null
+            },
+            "Phone" : {
+                "value" : "+1-719-555-1212",
+                "displayValue" : null
+            }
+
+        }
+    }
+ }

--- a/force-app/main/default/lwc/draftDetailsList/__tests__/draftDetailsList.test.js
+++ b/force-app/main/default/lwc/draftDetailsList/__tests__/draftDetailsList.test.js
@@ -1,0 +1,35 @@
+import { createElement } from "lwc";
+import DraftDetailsList from "c/draftDetailsList";
+import { getRecord } from "lightning/uiRecordApi";
+
+const mockGetRecord = require("./data/getRecord.json");
+
+describe("c-draft-details-list", () => {
+  afterEach(() => {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  it("should correctly populate draft list", async () => {
+    const element = createElement("c-draft-details-list", {
+      is: DraftDetailsList,
+    });
+    element.recordId = "abc123";
+    element.fields = [];
+
+    document.body.appendChild(element);
+
+    // Emit mock record into the wired field
+    // eslint-disable-next-line @lwc/lwc/no-unexpected-wire-adapter-usages
+    getRecord.emit(mockGetRecord);
+
+    // Resolve a promise to wait for a re-render of the new content
+    await Promise.resolve();
+    // our sample data has 2 draft edits (name and phone)
+    const draftEdits = element.shadowRoot.querySelectorAll("li");
+    expect(draftEdits[0].textContent).toBe("Name=Old Name");
+    expect(draftEdits[1].textContent).toBe("Phone=+1-719-555-1212");
+  });
+});

--- a/force-app/main/default/lwc/draftDetailsList/draftDetailsList.css
+++ b/force-app/main/default/lwc/draftDetailsList/draftDetailsList.css
@@ -1,0 +1,1 @@
+@import 'c/commonStyles';

--- a/force-app/main/default/lwc/draftDetailsList/draftDetailsList.html
+++ b/force-app/main/default/lwc/draftDetailsList/draftDetailsList.html
@@ -1,0 +1,15 @@
+<template>
+    <template if:true={drafts} >
+        <lightning-accordion allow-multiple-sections-open="true">
+            <lightning-accordion-section name="draftEdits" label="Draft - Original Values">
+                <ul class="slds-list_dotted">
+                    <template for:each={drafts} for:item="draft">
+                        <li key={draft.fieldName}>
+                            {draft.fieldName}={draft.value}
+                        </li>
+                    </template>
+                </ul>
+            </lightning-accordion-section>
+        </lightning-accordion>
+    </template>
+</template>

--- a/force-app/main/default/lwc/draftDetailsList/draftDetailsList.js
+++ b/force-app/main/default/lwc/draftDetailsList/draftDetailsList.js
@@ -1,0 +1,25 @@
+import { LightningElement, api, track, wire } from "lwc";
+import { getRecord } from "lightning/uiRecordApi";
+
+export default class DraftDetailsList extends LightningElement {
+  @api recordId;
+  @api fields;
+
+  @track drafts;
+
+  @wire(getRecord, { recordId: "$recordId", fields: "$fields" })
+  wiredRecord({ error, data }) {
+    if (data?.drafts?.serverValues) {
+      // flatten the serverValues
+      const draftChanges = data?.drafts?.serverValues;
+      const serverChanges = Object.keys(draftChanges).map((key) => ({
+        fieldName: key,
+        ...draftChanges[key],
+      }));
+
+      this.drafts = serverChanges;
+    } else if (error) {
+      console.error("Error occurred retrieving drafts.", error);
+    }
+  }
+}

--- a/force-app/main/default/lwc/draftDetailsList/draftDetailsList.js-meta.xml
+++ b/force-app/main/default/lwc/draftDetailsList/draftDetailsList.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/recordHeader/__tests__/recordHeader.test.js
+++ b/force-app/main/default/lwc/recordHeader/__tests__/recordHeader.test.js
@@ -1,0 +1,40 @@
+import { createElement } from "lwc";
+import RecordHeader from "c/recordHeader";
+
+describe("c-record-header", () => {
+  afterEach(() => {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  it("should correctly populate record fields", async () => {
+    const element = createElement("c-record-header", {
+      is: RecordHeader,
+    });
+    element.recordName = "recordName";
+    element.objectApiName = "apiName";
+
+    document.body.appendChild(element);
+
+    // Resolve a promise to wait for a re-render of the new content
+    await Promise.resolve();
+    const iconField = element.shadowRoot.querySelector(
+      'lightning-icon[data-id="iconId"]'
+    );
+    expect(iconField.iconName).toBe(
+      "standard:" + element.objectApiName.toLowerCase()
+    );
+
+    const nameField = element.shadowRoot.querySelector(
+      'lightning-layout-item[data-id="nameId"]'
+    );
+    expect(nameField.textContent).toBe(element.recordName);
+
+    const objectField = element.shadowRoot.querySelector(
+      'lightning-layout-item[data-id="objectApiNameId"]'
+    );
+    expect(objectField.textContent).toBe(element.objectApiName);
+  });
+});

--- a/force-app/main/default/lwc/recordHeader/recordHeader.html
+++ b/force-app/main/default/lwc/recordHeader/recordHeader.html
@@ -1,0 +1,22 @@
+<template>
+
+    <!-- Show the record type icon, object api name, and record name -->
+    <lightning-layout vertical-align="center">
+        <lightning-layout-item class="slds-var-p-around_small">
+            <lightning-icon icon-name={cardIconName} size="medium" data-id="iconId"
+                data-name={cardIconName}></lightning-icon>
+        </lightning-layout-item>
+
+        <lightning-layout-item>
+            <lightning-layout multiple-rows>
+                <lightning-layout-item size=12 class="record-name" data-id="nameId">
+                    <p style="word-break: break-all;">{recordName}</p>
+                </lightning-layout-item>
+                <lightning-layout-item size=12 class="object-name" data-id="objectApiNameId">
+                    <p style="word-break: break-all;">{objectApiName}</p>
+                </lightning-layout-item>
+            </lightning-layout>
+        </lightning-layout-item>
+    </lightning-layout>
+
+</template>

--- a/force-app/main/default/lwc/recordHeader/recordHeader.js
+++ b/force-app/main/default/lwc/recordHeader/recordHeader.js
@@ -1,0 +1,12 @@
+import { LightningElement, api } from "lwc";
+
+export default class RecordHeader extends LightningElement {
+  @api recordName;
+  @api objectApiName;
+
+  get cardIconName() {
+    return `standard:${
+      this.objectApiName ? this.objectApiName.toLowerCase() : ""
+    }`;
+  }
+}

--- a/force-app/main/default/lwc/recordHeader/recordHeader.js-meta.xml
+++ b/force-app/main/default/lwc/recordHeader/recordHeader.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/viewAccountRecord/__tests__/data/getRecord.json
+++ b/force-app/main/default/lwc/viewAccountRecord/__tests__/data/getRecord.json
@@ -1,36 +1,7 @@
 {
     "fields": {
         "Name": {
-            "value": "Name Mock"
-        },
-        "Phone": {
-            "value": "123-456-7890"
-        },
-        "Website": {
-            "value": "www.mocksite.fake"
-        },
-        "Owner.Name": {
-            "value": "Owner name"
-        },
-        "Industry": {
-            "value": "Industry mock"
-        },
-        "Type": {
-            "value": "Record type"
-        }
-    },
-
-    "drafts": {
-        "serverValues" : {
-            "Name" : {
-                "value" : "Old Name",
-                "displayValue" : null
-            },
-            "Phone" : {
-                "value" : "+1-719-555-1212",
-                "displayValue" : null
-            }
-
+            "value": "Mock Account"
         }
     }
  }

--- a/force-app/main/default/lwc/viewAccountRecord/__tests__/viewAccountRecord.test.js
+++ b/force-app/main/default/lwc/viewAccountRecord/__tests__/viewAccountRecord.test.js
@@ -1,6 +1,11 @@
 import { createElement } from "lwc";
 import ViewAccountRecord from "c/viewAccountRecord";
 import { getRecord } from "lightning/uiRecordApi";
+import NAME_FIELD from "@salesforce/schema/Account.Name";
+import PHONE_FIELD from "@salesforce/schema/Account.Phone";
+import WEBSITE_FIELD from "@salesforce/schema/Account.Website";
+import INDUSTRY_FIELD from "@salesforce/schema/Account.Industry";
+import TYPE_FIELD from "@salesforce/schema/Account.Type";
 
 const mockGetRecord = require("./data/getRecord.json");
 
@@ -12,11 +17,12 @@ describe("c-view-account-record", () => {
     }
   });
 
-  it("should correctly populate record fields", () => {
+  it("should correctly populate record fields", async () => {
     const element = createElement("c-view-account-record", {
       is: ViewAccountRecord,
     });
-    element.objectApiName = "objectApiName";
+    element.recordId = "0011700000pJRRSAA4";
+    element.objectApiName = "Account";
     document.body.appendChild(element);
 
     // Emit mock record into the wired field
@@ -24,28 +30,27 @@ describe("c-view-account-record", () => {
     getRecord.emit(mockGetRecord);
 
     // Resolve a promise to wait for a re-render of the new content
-    return Promise.resolve().then(() => {
-      const objectField = element.shadowRoot.querySelector(
-        'lightning-layout-item[data-id="objectApiNameId"]'
-      );
-      expect(objectField.textContent).toBe(element.objectApiName);
+    await Promise.resolve();
 
-      const nameField = element.shadowRoot.querySelector(
-        'lightning-layout-item[data-id="nameId"]'
-      );
-      expect(nameField.textContent).toBe(mockGetRecord.fields.Name.value);
+    // ensure record header exists
+    const recordHeader = element.shadowRoot.querySelector("c-record-header");
+    expect(recordHeader).not.toBeNull();
 
-      const iconField = element.shadowRoot.querySelector(
-        'lightning-icon[data-id="iconId"]'
-      );
-      expect(iconField.iconName).toBe(
-        "standard:" + element.objectApiName.toLowerCase()
-      );
+    // ensure record form exists and was invoked with expected args
+    const formEl = element.shadowRoot.querySelector("lightning-record-form");
+    expect(formEl).not.toBeNull();
+    expect(formEl.recordId).toBe(element.recordId);
+    expect(formEl.objectApiName).toBe(element.objectApiName);
+    expect(formEl.fields).toEqual([
+      NAME_FIELD,
+      PHONE_FIELD,
+      WEBSITE_FIELD,
+      INDUSTRY_FIELD,
+      TYPE_FIELD,
+    ]);
 
-      // our sample data also has 2 draft edits (name and phone)
-      const draftEdits = element.shadowRoot.querySelectorAll("li");
-      expect(draftEdits[0].textContent).toBe("Name=Old Name");
-      expect(draftEdits[1].textContent).toBe("Phone=+1-719-555-1212");
-    });
+    // check draft list
+    const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
+    expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.html
+++ b/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.html
@@ -4,23 +4,7 @@
             <div class="card-container">
                 
                 <div class="title-slot">
-                    <!-- Show a header with the icon, object api name, and record name -->
-                    <lightning-layout vertical-align="center">
-                        <lightning-layout-item class="slds-var-p-around_small">
-                            <lightning-icon icon-name={cardIconName} size="medium" data-id="iconId" data-name={cardIconName}></lightning-icon>
-                        </lightning-layout-item>
-                    
-                        <lightning-layout-item>
-                            <lightning-layout multiple-rows>
-                                <lightning-layout-item size=12 class="record-name" data-id="nameId">
-                                    <p style="word-break: break-all;">{name}</p>
-                                </lightning-layout-item>
-                                <lightning-layout-item size=12 class="object-name" data-id="objectApiNameId">
-                                    <p style="word-break: break-all;">{objectApiName}</p>
-                                </lightning-layout-item>
-                            </lightning-layout>
-                        </lightning-layout-item>
-                    </lightning-layout>
+                    <c-record-header record-name={name} object-api-name={objectApiName}></c-record-header>
                 </div>
 
                 <div class="body-slot">
@@ -31,19 +15,7 @@
                 </div>
 
                 <!-- show any draft information for this record -->
-                <template if:true={draftDetails} >
-                    <lightning-accordion allow-multiple-sections-open="true">
-                        <lightning-accordion-section name="draftEdits" label="Draft - Original Values">
-                            <ul class="slds-list_dotted">
-                                <template for:each={draftDetails} for:item="draftItem">
-                                    <li key={draftItem.fieldName}>
-                                        {draftItem.fieldName}={draftItem.value}
-                                    </li>
-                                </template>
-                            </ul>
-                        </lightning-accordion-section>
-                    </lightning-accordion>
-                </template>
+                <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list>
             </div>
         </template>
     </div>

--- a/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js
+++ b/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js
@@ -18,41 +18,6 @@ export default class ViewAccountRecord extends LightningElement {
   record;
 
   get name() {
-    return this.recordDataExists &&
-      this.record.data.fields &&
-      this.record.data.fields.Name
-      ? this.record.data.fields.Name.value
-      : "";
-  }
-
-  get draftDetails() {
-    if (
-      !(
-        this.recordDataExists &&
-        this.record.data.drafts &&
-        this.record.data.drafts.serverValues
-      )
-    ) {
-      return null;
-    }
-
-    // flatten the serverValues
-    const draftChanges = this.record.data.drafts.serverValues;
-    const serverChanges = Object.keys(draftChanges).map((key) => ({
-      fieldName: key,
-      ...draftChanges[key],
-    }));
-
-    return serverChanges;
-  }
-
-  get cardIconName() {
-    return `standard:${
-      this.objectApiName ? this.objectApiName.toLowerCase() : ""
-    }`;
-  }
-
-  get recordDataExists() {
-    return this.record && this.record.data;
+    return this.record?.data?.fields?.Name?.value ?? "";
   }
 }

--- a/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js-meta.xml
+++ b/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js-meta.xml
@@ -2,6 +2,8 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
+    <masterLabel>View Account</masterLabel>
+    <description>Component to view a single Account. Will also display any draft items in accordion if any drafts exist for the record.</description>
     <targets>
         <target>lightning__RecordPage</target>
         <target>lightning__RecordAction</target>

--- a/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js-meta.xml
+++ b/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>View Account</masterLabel>
+    <masterLabel>View Account Record</masterLabel>
     <description>Component to view a single Account. Will also display any draft items in accordion if any drafts exist for the record.</description>
     <targets>
         <target>lightning__RecordPage</target>

--- a/force-app/main/default/lwc/viewContactRecord/__tests__/data/getRecord.json
+++ b/force-app/main/default/lwc/viewContactRecord/__tests__/data/getRecord.json
@@ -1,0 +1,7 @@
+{
+    "fields": {
+        "Name": {
+            "value": "Mock Contact"
+        }
+    }
+ }

--- a/force-app/main/default/lwc/viewContactRecord/__tests__/viewContactRecord.test.js
+++ b/force-app/main/default/lwc/viewContactRecord/__tests__/viewContactRecord.test.js
@@ -1,0 +1,60 @@
+import { createElement } from "lwc";
+import { getRecord } from "lightning/uiRecordApi";
+import ViewContactRecord from "c/viewContactRecord";
+import CONTACT_NAME_FIELD from "@salesforce/schema/Contact.Name";
+import CONTACT_TITLE_FIELD from "@salesforce/schema/Contact.Title";
+import CONTACT_ACCOUNT_FIELD from "@salesforce/schema/Contact.AccountId";
+import CONTACT_PHONE_FIELD from "@salesforce/schema/Contact.Phone";
+import CONTACT_EMAIL_FIELD from "@salesforce/schema/Contact.Email";
+import CONTACT_MOBILE_FIELD from "@salesforce/schema/Contact.MobilePhone";
+import CONTACT_CONTACT_OWNER_FIELD from "@salesforce/schema/Contact.OwnerId";
+
+const mockGetRecord = require("./data/getRecord.json");
+
+describe("c-view-contact-record", () => {
+  afterEach(() => {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  it("should correctly populate record fields", async () => {
+    const element = createElement("c-view-contact-record", {
+      is: ViewContactRecord,
+    });
+    element.recordId = "0031700000pJRRSAA4";
+    element.objectApiName = "Contact";
+    document.body.appendChild(element);
+
+    // Emit mock record into the wired field
+    // eslint-disable-next-line @lwc/lwc/no-unexpected-wire-adapter-usages
+    getRecord.emit(mockGetRecord);
+
+    // Resolve a promise to wait for a re-render of the new content
+    await Promise.resolve();
+
+    // ensure record header exists
+    const recordHeader = element.shadowRoot.querySelector("c-record-header");
+    expect(recordHeader).not.toBeNull();
+
+    // ensure record form exists and was invoked with expected args
+    const formEl = element.shadowRoot.querySelector("lightning-record-form");
+    expect(formEl).not.toBeNull();
+    expect(formEl.recordId).toBe(element.recordId);
+    expect(formEl.objectApiName).toBe(element.objectApiName);
+    expect(formEl.fields).toEqual([
+      CONTACT_NAME_FIELD,
+      CONTACT_TITLE_FIELD,
+      CONTACT_ACCOUNT_FIELD,
+      CONTACT_PHONE_FIELD,
+      CONTACT_EMAIL_FIELD,
+      CONTACT_MOBILE_FIELD,
+      CONTACT_CONTACT_OWNER_FIELD,
+    ]);
+
+    // check draft list
+    const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
+    expect(draftEdits).not.toBeNull();
+  });
+});

--- a/force-app/main/default/lwc/viewContactRecord/__tests__/viewContactRecord.test.js
+++ b/force-app/main/default/lwc/viewContactRecord/__tests__/viewContactRecord.test.js
@@ -7,7 +7,7 @@ import CONTACT_ACCOUNT_FIELD from "@salesforce/schema/Contact.AccountId";
 import CONTACT_PHONE_FIELD from "@salesforce/schema/Contact.Phone";
 import CONTACT_EMAIL_FIELD from "@salesforce/schema/Contact.Email";
 import CONTACT_MOBILE_FIELD from "@salesforce/schema/Contact.MobilePhone";
-import CONTACT_CONTACT_OWNER_FIELD from "@salesforce/schema/Contact.OwnerId";
+import CONTACT_OWNER_FIELD from "@salesforce/schema/Contact.OwnerId";
 
 const mockGetRecord = require("./data/getRecord.json");
 
@@ -50,7 +50,7 @@ describe("c-view-contact-record", () => {
       CONTACT_PHONE_FIELD,
       CONTACT_EMAIL_FIELD,
       CONTACT_MOBILE_FIELD,
-      CONTACT_CONTACT_OWNER_FIELD,
+      CONTACT_OWNER_FIELD,
     ]);
 
     // check draft list

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.css
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.css
@@ -1,0 +1,1 @@
+@import 'c/commonStyles';

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.html
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.html
@@ -1,0 +1,22 @@
+<template>
+    <div class="component-background">
+        <template if:true={record}>
+            <div class="card-container">
+                
+                <div class="title-slot">
+                    <c-record-header record-name={name} object-api-name={objectApiName}></c-record-header>
+                </div>
+
+                <div class="body-slot">
+                    <!-- use lightning-record-form to show the selected fields. here, we use 'view' as the mode which allows edits too -->
+                    <lightning-record-form record-id={recordId} object-api-name={objectApiName} fields={fields}
+                        columns="1" mode="readonly">
+                    </lightning-record-form>
+                </div>
+
+                <!-- show any draft information for this record -->
+                <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list>
+            </div>
+        </template>
+    </div>
+</template>

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js
@@ -6,7 +6,7 @@ import CONTACT_ACCOUNT_FIELD from "@salesforce/schema/Contact.AccountId";
 import CONTACT_PHONE_FIELD from "@salesforce/schema/Contact.Phone";
 import CONTACT_EMAIL_FIELD from "@salesforce/schema/Contact.Email";
 import CONTACT_MOBILE_FIELD from "@salesforce/schema/Contact.MobilePhone";
-import CONTACT_CONTACT_OWNER_FIELD from "@salesforce/schema/Contact.OwnerId";
+import CONTACT_OWNER_FIELD from "@salesforce/schema/Contact.OwnerId";
 
 export default class ViewContactRecord extends LightningElement {
   @api recordId;
@@ -20,7 +20,7 @@ export default class ViewContactRecord extends LightningElement {
       CONTACT_PHONE_FIELD,
       CONTACT_EMAIL_FIELD,
       CONTACT_MOBILE_FIELD,
-      CONTACT_CONTACT_OWNER_FIELD,
+      CONTACT_OWNER_FIELD,
     ];
   }
 

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js
@@ -1,0 +1,33 @@
+import { LightningElement, api, wire } from "lwc";
+import { getRecord } from "lightning/uiRecordApi";
+import CONTACT_NAME_FIELD from "@salesforce/schema/Contact.Name";
+import CONTACT_TITLE_FIELD from "@salesforce/schema/Contact.Title";
+import CONTACT_ACCOUNT_FIELD from "@salesforce/schema/Contact.AccountId";
+import CONTACT_PHONE_FIELD from "@salesforce/schema/Contact.Phone";
+import CONTACT_EMAIL_FIELD from "@salesforce/schema/Contact.Email";
+import CONTACT_MOBILE_FIELD from "@salesforce/schema/Contact.MobilePhone";
+import CONTACT_CONTACT_OWNER_FIELD from "@salesforce/schema/Contact.OwnerId";
+
+export default class ViewContactRecord extends LightningElement {
+  @api recordId;
+  @api objectApiName;
+
+  get fields() {
+    return [
+      CONTACT_NAME_FIELD,
+      CONTACT_TITLE_FIELD,
+      CONTACT_ACCOUNT_FIELD,
+      CONTACT_PHONE_FIELD,
+      CONTACT_EMAIL_FIELD,
+      CONTACT_MOBILE_FIELD,
+      CONTACT_CONTACT_OWNER_FIELD,
+    ];
+  }
+
+  @wire(getRecord, { recordId: "$recordId", fields: "$fields" })
+  record;
+
+  get name() {
+    return this.record?.data?.fields?.Name?.value ?? "";
+  }
+}

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js-meta.xml
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__RecordAction</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordAction">
+            <actionType>ScreenAction</actionType>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js-meta.xml
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js-meta.xml
@@ -2,6 +2,8 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
+    <masterLabel>View Contact</masterLabel>
+    <description>Component to view a single Contact. Will also display any draft items in accordion if any drafts exist for the record.</description>
     <targets>
         <target>lightning__RecordPage</target>
         <target>lightning__RecordAction</target>

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js-meta.xml
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>View Contact</masterLabel>
+    <masterLabel>View Contact Record</masterLabel>
     <description>Component to view a single Contact. Will also display any draft items in accordion if any drafts exist for the record.</description>
     <targets>
         <target>lightning__RecordPage</target>

--- a/force-app/main/default/lwc/viewOpportunityRecord/__tests__/data/getRecord.json
+++ b/force-app/main/default/lwc/viewOpportunityRecord/__tests__/data/getRecord.json
@@ -1,0 +1,7 @@
+{
+    "fields": {
+        "Name": {
+            "value": "Mock Opportunity"
+        }
+    }
+ }

--- a/force-app/main/default/lwc/viewOpportunityRecord/__tests__/viewOpportunityRecord.test.js
+++ b/force-app/main/default/lwc/viewOpportunityRecord/__tests__/viewOpportunityRecord.test.js
@@ -47,7 +47,6 @@ describe("c-view-opportunity-record", () => {
       OPPORTUNITY_CLOSE_DATE_FIELD,
       OPPORTUNITY_AMOUNT_FIELD,
       OPPORTUNITY_OWNER_FIELD,
-      { objectApiName: "Opportunity", fieldApiName: "IqScore" },
     ]);
 
     // check draft list

--- a/force-app/main/default/lwc/viewOpportunityRecord/__tests__/viewOpportunityRecord.test.js
+++ b/force-app/main/default/lwc/viewOpportunityRecord/__tests__/viewOpportunityRecord.test.js
@@ -1,0 +1,57 @@
+import { createElement } from "lwc";
+import { getRecord } from "lightning/uiRecordApi";
+import ViewOpportunityRecord from "c/viewOpportunityRecord";
+import OPPORTUNITY_NAME_FIELD from "@salesforce/schema/Opportunity.Name";
+import OPPORTUNITY_ACCOUNT_FIELD from "@salesforce/schema/Opportunity.AccountId";
+import OPPORTUNITY_CLOSE_DATE_FIELD from "@salesforce/schema/Opportunity.CloseDate";
+import OPPORTUNITY_AMOUNT_FIELD from "@salesforce/schema/Opportunity.Amount";
+import OPPORTUNITY_OWNER_FIELD from "@salesforce/schema/Opportunity.OwnerId";
+
+const mockGetRecord = require("./data/getRecord.json");
+
+describe("c-view-opportunity-record", () => {
+  afterEach(() => {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  it("should correctly populate record fields", async () => {
+    const element = createElement("c-view-contact-record", {
+      is: ViewOpportunityRecord,
+    });
+    element.recordId = "0061700000pJRRSAA4";
+    element.objectApiName = "Opportunity";
+    document.body.appendChild(element);
+
+    // Emit mock record into the wired field
+    // eslint-disable-next-line @lwc/lwc/no-unexpected-wire-adapter-usages
+    getRecord.emit(mockGetRecord);
+
+    // Resolve a promise to wait for a re-render of the new content
+    await Promise.resolve();
+
+    // ensure record header exists
+    const recordHeader = element.shadowRoot.querySelector("c-record-header");
+    expect(recordHeader).not.toBeNull();
+
+    // ensure record form exists and was invoked with expected args
+    const formEl = element.shadowRoot.querySelector("lightning-record-form");
+    expect(formEl).not.toBeNull();
+    expect(formEl.recordId).toBe(element.recordId);
+    expect(formEl.objectApiName).toBe(element.objectApiName);
+    expect(formEl.fields).toEqual([
+      OPPORTUNITY_NAME_FIELD,
+      OPPORTUNITY_ACCOUNT_FIELD,
+      OPPORTUNITY_CLOSE_DATE_FIELD,
+      OPPORTUNITY_AMOUNT_FIELD,
+      OPPORTUNITY_OWNER_FIELD,
+      { objectApiName: "Opportunity", fieldApiName: "IqScore" },
+    ]);
+
+    // check draft list
+    const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
+    expect(draftEdits).not.toBeNull();
+  });
+});

--- a/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.css
+++ b/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.css
@@ -1,0 +1,1 @@
+@import 'c/commonStyles';

--- a/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.html
+++ b/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.html
@@ -1,0 +1,22 @@
+<template>
+    <div class="component-background">
+        <template if:true={record}>
+            <div class="card-container">
+                
+                <div class="title-slot">
+                    <c-record-header record-name={name} object-api-name={objectApiName}></c-record-header>
+                </div>
+
+                <div class="body-slot">
+                    <!-- use lightning-record-form to show the selected fields. here, we use 'view' as the mode which allows edits too -->
+                    <lightning-record-form record-id={recordId} object-api-name={objectApiName} fields={fields}
+                        columns="1" mode="readonly">
+                    </lightning-record-form>
+                </div>
+
+                <!-- show any draft information for this record -->
+                <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list>
+            </div>
+        </template>
+    </div>
+</template>

--- a/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js
+++ b/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js
@@ -17,7 +17,6 @@ export default class ViewOpportunityRecord extends LightningElement {
       OPPORTUNITY_CLOSE_DATE_FIELD,
       OPPORTUNITY_AMOUNT_FIELD,
       OPPORTUNITY_OWNER_FIELD,
-      { objectApiName: "Opportunity", fieldApiName: "IqScore" },
     ];
   }
 

--- a/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js
+++ b/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js
@@ -1,0 +1,30 @@
+import { LightningElement, api, wire } from "lwc";
+import { getRecord } from "lightning/uiRecordApi";
+import OPPORTUNITY_NAME_FIELD from "@salesforce/schema/Opportunity.Name";
+import OPPORTUNITY_ACCOUNT_FIELD from "@salesforce/schema/Opportunity.AccountId";
+import OPPORTUNITY_CLOSE_DATE_FIELD from "@salesforce/schema/Opportunity.CloseDate";
+import OPPORTUNITY_AMOUNT_FIELD from "@salesforce/schema/Opportunity.Amount";
+import OPPORTUNITY_OWNER_FIELD from "@salesforce/schema/Opportunity.OwnerId";
+
+export default class ViewOpportunityRecord extends LightningElement {
+  @api recordId;
+  @api objectApiName;
+
+  get fields() {
+    return [
+      OPPORTUNITY_NAME_FIELD,
+      OPPORTUNITY_ACCOUNT_FIELD,
+      OPPORTUNITY_CLOSE_DATE_FIELD,
+      OPPORTUNITY_AMOUNT_FIELD,
+      OPPORTUNITY_OWNER_FIELD,
+      { objectApiName: "Opportunity", fieldApiName: "IqScore" },
+    ];
+  }
+
+  @wire(getRecord, { recordId: "$recordId", fields: "$fields" })
+  record;
+
+  get name() {
+    return this.record?.data?.fields?.Name?.value ?? "";
+  }
+}

--- a/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js-meta.xml
+++ b/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__RecordAction</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordAction">
+            <actionType>ScreenAction</actionType>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js-meta.xml
+++ b/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js-meta.xml
@@ -2,6 +2,8 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
+    <masterLabel>View Opportunity</masterLabel>
+    <description>Component to view a single Opportunity. Will also display any draft items in accordion if any drafts exist for the record.</description>
     <targets>
         <target>lightning__RecordPage</target>
         <target>lightning__RecordAction</target>

--- a/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js-meta.xml
+++ b/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>View Opportunity</masterLabel>
+    <masterLabel>View Opportunity Record    </masterLabel>
     <description>Component to view a single Opportunity. Will also display any draft items in accordion if any drafts exist for the record.</description>
     <targets>
         <target>lightning__RecordPage</target>


### PR DESCRIPTION
For now, it is difficult to share code across the LWCs, so I refactored out the recordHeader and draftDetails into a reusable component. This makes the html files identical for all 3, and the only difference in the JS files are the list of fields. (I attempted in [this PR](https://github.com/salesforce/offline-app-developer-starter-kit/pull/31) to make it generic, but it is not working offline yet.)

@khawkins @AdamLiechty @sfdctaka @maliroteh-sf @andrew-gomez-sfdc 