### PR TITLE
Min Node 16, bumping API version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 14, 16 ]
+        node: [ 16, 18 ]
     name: Linting on Ubuntu with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 14, 16 ]
+        node: [ 16, 18 ]
     name: Prettier on Ubuntu with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 14, 16 ]
+        node: [ 16, 18 ]
     name: Tests on Ubuntu with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "prettier": "^2.7.1",
         "prettier-plugin-apex": "^1.11.0",
         "typescript": "^4.9.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -30,5 +30,11 @@
     "prettier": "^2.7.1",
     "prettier-plugin-apex": "^1.11.0",
     "typescript": "^4.9.3"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "volta": {
+    "node": "16.20.0"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,5 +7,5 @@
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "55.0"
+  "sourceApiVersion": "58.0"
 }


### PR DESCRIPTION
Since Node 14 is EOL, let's start Summer '23 on a minimum of Node 16.