### PR TITLE
Fixing create* LWCs

### DIFF
--- a/force-app/main/default/lwc/createContactRecord/createContactRecord.html
+++ b/force-app/main/default/lwc/createContactRecord/createContactRecord.html
@@ -17,8 +17,6 @@
                 </lightning-layout>
             </div>
 
-
-
             <div class="header-offset slds-var-p-horizontal_small slds-var-p-bottom_medium">
 
                 <!-- show any error messages or alerts -->
@@ -31,7 +29,7 @@
                 <lightning-input-field field-name={phoneField} value={phone}></lightning-input-field>
                 <lightning-input-field field-name={emailField} value={email}></lightning-input-field>
                 <lightning-input-field field-name={mobileField} value={mobile}></lightning-input-field>
-                <lightning-input-field field-name={ownerField} value={owner}></lightning-input-field>
+                <lightning-input-field field-name={ownerField}></lightning-input-field>
 
             </div>
 

--- a/force-app/main/default/lwc/createContactRecord/createContactRecord.js
+++ b/force-app/main/default/lwc/createContactRecord/createContactRecord.js
@@ -25,7 +25,6 @@ export default class CreateContactRecord extends LightningElement {
   phone = "";
   email = "";
   mobile = "";
-  owner = "";
 
   onSuccess(event) {
     console.log("Created contact", event.detail);

--- a/force-app/main/default/lwc/createOpportunityRecord/__tests__/createOpportunityRecord.test.js
+++ b/force-app/main/default/lwc/createOpportunityRecord/__tests__/createOpportunityRecord.test.js
@@ -6,6 +6,7 @@ import OPPORTUNITY_ACCOUNT_FIELD from "@salesforce/schema/Opportunity.AccountId"
 import OPPORTUNITY_CLOSE_DATE_FIELD from "@salesforce/schema/Opportunity.CloseDate";
 import OPPORTUNITY_AMOUNT_FIELD from "@salesforce/schema/Opportunity.Amount";
 import OPPORTUNITY_OWNER_FIELD from "@salesforce/schema/Opportunity.OwnerId";
+import OPPORTUNITY_STAGENAME_FIELD from "@salesforce/schema/Opportunity.StageName";
 
 describe("c-create-opportunity-record", () => {
   afterEach(() => {
@@ -43,6 +44,7 @@ describe("c-create-opportunity-record", () => {
       OPPORTUNITY_ACCOUNT_FIELD,
       OPPORTUNITY_CLOSE_DATE_FIELD,
       OPPORTUNITY_AMOUNT_FIELD,
+      OPPORTUNITY_STAGENAME_FIELD,
       OPPORTUNITY_OWNER_FIELD,
     ];
 

--- a/force-app/main/default/lwc/createOpportunityRecord/createOpportunityRecord.html
+++ b/force-app/main/default/lwc/createOpportunityRecord/createOpportunityRecord.html
@@ -17,8 +17,6 @@
                 </lightning-layout>
             </div>
 
-
-
             <div class="header-offset slds-var-p-horizontal_small slds-var-p-bottom_medium">
 
                 <!-- show any error messages or alerts -->
@@ -29,7 +27,8 @@
                 <lightning-input-field field-name={accountField} value={account}></lightning-input-field>
                 <lightning-input-field field-name={closeDateField} value={closeDate}></lightning-input-field>
                 <lightning-input-field field-name={amountField} value={amount}></lightning-input-field>
-                <lightning-input-field field-name={ownerField} value={owner}></lightning-input-field>
+                <lightning-input-field field-name={stageNameField} value={stageName}></lightning-input-field>
+                <lightning-input-field field-name={ownerField}></lightning-input-field>
 
             </div>
 

--- a/force-app/main/default/lwc/createOpportunityRecord/createOpportunityRecord.js
+++ b/force-app/main/default/lwc/createOpportunityRecord/createOpportunityRecord.js
@@ -3,6 +3,7 @@ import OPPORTUNITY_NAME_FIELD from "@salesforce/schema/Opportunity.Name";
 import OPPORTUNITY_ACCOUNT_FIELD from "@salesforce/schema/Opportunity.AccountId";
 import OPPORTUNITY_CLOSE_DATE_FIELD from "@salesforce/schema/Opportunity.CloseDate";
 import OPPORTUNITY_AMOUNT_FIELD from "@salesforce/schema/Opportunity.Amount";
+import OPPORTUNITY_STAGENAME_FIELD from "@salesforce/schema/Opportunity.StageName";
 import OPPORTUNITY_OWNER_FIELD from "@salesforce/schema/Opportunity.OwnerId";
 
 export default class CreateContactRecord extends LightningElement {
@@ -13,13 +14,14 @@ export default class CreateContactRecord extends LightningElement {
   accountField = OPPORTUNITY_ACCOUNT_FIELD;
   closeDateField = OPPORTUNITY_CLOSE_DATE_FIELD;
   amountField = OPPORTUNITY_AMOUNT_FIELD;
+  stageNameField = OPPORTUNITY_STAGENAME_FIELD;
   ownerField = OPPORTUNITY_OWNER_FIELD;
 
   name = "";
   account = "";
   closeDate = "";
   amount = "";
-  owner = "";
+  stageName = "";
 
   onSuccess(event) {
     console.log("Created opportunity", event.detail);


### PR DESCRIPTION
Two issues: 1) LWCs were attempting to pass "" value for readonly ownerid fields, and 2) stageName is a required field on Oppty, but does not exist on compact layout (where the requirements came from).

@khawkins @apaschapur @sfdctaka @maliroteh-sf 