### PR TITLE
Bump eslint plugin version.

### DIFF
--- a/force-app/main/default/lwc/accountRelatedContacts/accountRelatedContacts.js
+++ b/force-app/main/default/lwc/accountRelatedContacts/accountRelatedContacts.js
@@ -3,6 +3,7 @@ import { NavigationMixin } from "lightning/navigation";
 
 import { graphql, gql } from "lightning/uiGraphQLApi";
 
+// eslint-disable-next-line @salesforce/lwc-graph-analyzer/no-unresolved-parent-class-reference
 export default class AccountRelatedContacts extends NavigationMixin(
   LightningElement
 ) {

--- a/force-app/main/default/lwc/accountRelatedContacts/accountRelatedContacts.js
+++ b/force-app/main/default/lwc/accountRelatedContacts/accountRelatedContacts.js
@@ -41,6 +41,8 @@ export default class AccountRelatedContacts extends NavigationMixin(
   `;
 
   // https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_graphql_relationships
+  //
+  // eslint-disable-next-line @salesforce/lwc-graph-analyzer/no-wire-adapter-of-resource-cannot-be-primed
   @wire(graphql, {
     query: "$accountQuery",
     variables: "$graphqlVariables",

--- a/force-app/main/default/lwc/errorPanel/errorPanel.js
+++ b/force-app/main/default/lwc/errorPanel/errorPanel.js
@@ -12,6 +12,7 @@ export default class ErrorPanel extends LightningElement {
   viewDetails = false;
 
   get errorMessages() {
+    // eslint-disable-next-line @salesforce/lwc-graph-analyzer/no-call-expression-references-unsupported-namespace
     return reduceErrors(this.errors);
   }
 

--- a/force-app/main/default/lwc/locationService/locationService.js
+++ b/force-app/main/default/lwc/locationService/locationService.js
@@ -1,18 +1,18 @@
-import { LightningElement, api } from "lwc";
+import { LightningElement, track } from "lwc";
 import { getLocationService } from "lightning/mobileCapabilities";
 
 export default class LocationService extends LightningElement {
-  @api errorMessage;
-  @api currentLatitude;
-  @api currentLongitude;
+  @track errorMessage;
+  @track currentLatitude;
+  @track currentLongitude;
 
   locationService;
-  @api locationButtonDisabled = false;
+  @track locationButtonDisabled = false;
   requestInProgress = false;
   showInstruction = true;
   buttonInstruction = "Get Current Location";
-  @api buttonText = this.buttonInstruction;
-  @api interstitialMessage = "Fetching your current location...";
+  @track buttonText = this.buttonInstruction;
+  @track interstitialMessage = "Fetching your current location...";
 
   // When the component is initialized, detect whether to enable the button
   connectedCallback() {
@@ -24,10 +24,11 @@ export default class LocationService extends LightningElement {
   }
 
   get hasCurrentLocation() {
+    // eslint-disable-next-line @salesforce/lwc-graph-analyzer/no-unsupported-member-variable-in-member-expression
     return this.currentLatitude && this.currentLongitude;
   }
 
-  handleGetCurrentLocationClick(event) {
+  handleGetCurrentLocationClick() {
     if (this.locationService != null && this.locationService.isAvailable()) {
       // Reset current location
       this.currentLatitude = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@salesforce/eslint-config-lwc": "^3.3.3",
         "@salesforce/eslint-plugin-aura": "^2.1.0",
         "@salesforce/eslint-plugin-lightning": "^1.0.0",
-        "@salesforce/eslint-plugin-lwc-graph-analyzer": "^0.7.0",
+        "@salesforce/eslint-plugin-lwc-graph-analyzer": "^0.7.1",
         "@salesforce/sfdx-lwc-jest": "^1.4.1",
         "eslint": "^8.27.0",
         "eslint-config-prettier": "^8.5.0",
@@ -2503,9 +2503,9 @@
       }
     },
     "node_modules/@salesforce/eslint-plugin-lwc-graph-analyzer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/eslint-plugin-lwc-graph-analyzer/-/eslint-plugin-lwc-graph-analyzer-0.7.0.tgz",
-      "integrity": "sha512-CJVogaOm5w+CpyhbIhaD0U69GPWf7yyyTPiBPD82DBl05gTGDiC82NH6xtL/HKC9XICcISdCimLiuDYL4ChCAA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/eslint-plugin-lwc-graph-analyzer/-/eslint-plugin-lwc-graph-analyzer-0.7.1.tgz",
+      "integrity": "sha512-R2Ppxajo3Ey9vuhzeBpfOcGynadMVT7lHhWhT8lNg4UNr+l+gYinEGWrWrGIzIkV2LrMOtfkmq0crphuhpZkIg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.20.2",
@@ -14203,9 +14203,9 @@
       "requires": {}
     },
     "@salesforce/eslint-plugin-lwc-graph-analyzer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/eslint-plugin-lwc-graph-analyzer/-/eslint-plugin-lwc-graph-analyzer-0.7.0.tgz",
-      "integrity": "sha512-CJVogaOm5w+CpyhbIhaD0U69GPWf7yyyTPiBPD82DBl05gTGDiC82NH6xtL/HKC9XICcISdCimLiuDYL4ChCAA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/eslint-plugin-lwc-graph-analyzer/-/eslint-plugin-lwc-graph-analyzer-0.7.1.tgz",
+      "integrity": "sha512-R2Ppxajo3Ey9vuhzeBpfOcGynadMVT7lHhWhT8lNg4UNr+l+gYinEGWrWrGIzIkV2LrMOtfkmq0crphuhpZkIg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.20.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@salesforce/eslint-config-lwc": "^3.3.3",
     "@salesforce/eslint-plugin-aura": "^2.1.0",
     "@salesforce/eslint-plugin-lightning": "^1.0.0",
-    "@salesforce/eslint-plugin-lwc-graph-analyzer": "^0.7.0",
+    "@salesforce/eslint-plugin-lwc-graph-analyzer": "^0.7.1",
     "@salesforce/sfdx-lwc-jest": "^1.4.1",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
The latest version of eslint plugin LWC graph analyzer has a bug fix that will suppress lint warnings when `//eslint-disable` variants are used.