### PR TITLE
Added optional iconName attribute 

### DIFF
--- a/force-app/main/default/lwc/recordHeader/recordHeader.js
+++ b/force-app/main/default/lwc/recordHeader/recordHeader.js
@@ -3,10 +3,16 @@ import { LightningElement, api } from "lwc";
 export default class RecordHeader extends LightningElement {
   @api recordName;
   @api objectApiName;
+  @api iconName;
 
   get cardIconName() {
     return `standard:${
-      this.objectApiName ? this.objectApiName.toLowerCase() : ""
+      this.iconName
+        ? this.iconName
+        : this.objectApiName
+        ? this.objectApiName.toLowerCase()
+        : ""
     }`;
   }
 }
+


### PR DESCRIPTION
Added optional iconName attribute that allows for icons not matching object name

html: 
<c-record-header record-name={name} object-api-name={objectApiName} icon-name={iconNameNotEqualToObjectName}></c-record-header>

js: 

 get iconNameNotEqualToObjectName() {
    return "asset_object";
  }
