### PR TITLE
Fix barcode scanner showing incorrect product record

### DIFF
--- a/force-app/main/default/lwc/scanBarcodeLookUp/scanBarcodeLookUp.js
+++ b/force-app/main/default/lwc/scanBarcodeLookUp/scanBarcodeLookUp.js
@@ -40,6 +40,8 @@ export default class ScanBarcodeLookup extends LightningElement {
   }
 
   get productQuery() {
+    if (!this.scannedBarcode) return undefined;
+
     return gql`
       query productBarcodeLookup($upc: String) {
         uiapi {


### PR DESCRIPTION
A record with an empty barcode value is displayed even without scanning a barcode. 
Added a check to see if the barcode is scanned before doing a GraphQL query.