### PR TITLE
Commenting out <c-draft-details-list> from view*Record components

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ cd force-app/main/default
   The `<lightningWebComponent>` element specifies the Lightning web component loaded for
   the given quick action. In this case, the `editAccountRecord` component.
 
+### View Draft Details within a Lightning Web Component
+
+It may be useful to view draft details within a record view Lightning Web Component for debugging purposes. To enable draft details, simply uncomment the `<c-draft-detailst-list>` component from the `view<Object>Record` component html. Don't forget to uncomment the respective test code to validate the expected behavior.
+
+> **Note**
+> Adding additional dependencies will negatively affect the total time to prime all records, as well as slightly increase single record load times. It is recommended to remove or comment out debug components such as `<c-draft-details-list>` from production code.
+
 ### Call Apex Methods from Lightning Web Components
 
 Apex methods can be called from Lightning web components. However, Apex is a server-side language, and Apex methods aren't available when offline. When developing for the Offline App, we recommend that you use base components and Lightning Data Service (LDS) via wire adapters for viewing or modifying data. See "[Data Guidelines](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.data_guidelines)" for a more detailed description of recommended strategies for data access within LWCs.

--- a/force-app/main/default/lwc/viewAccountRecord/__tests__/viewAccountRecord.test.js
+++ b/force-app/main/default/lwc/viewAccountRecord/__tests__/viewAccountRecord.test.js
@@ -51,8 +51,8 @@ describe("c-view-account-record", () => {
     ]);
 
     // check draft list
-    const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
     // Uncomment if using the c-draft-details-list component
+    // const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
     // expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewAccountRecord/__tests__/viewAccountRecord.test.js
+++ b/force-app/main/default/lwc/viewAccountRecord/__tests__/viewAccountRecord.test.js
@@ -52,6 +52,7 @@ describe("c-view-account-record", () => {
 
     // check draft list
     const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
-    expect(draftEdits).not.toBeNull();
+    // Uncomment if using the c-draft-details-list component
+    // expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.html
+++ b/force-app/main/default/lwc/viewAccountRecord/viewAccountRecord.html
@@ -15,7 +15,7 @@
                 </div>
 
                 <!-- show any draft information for this record -->
-                <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list>
+                <!-- <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list> -->
             </div>
         </template>
     </div>

--- a/force-app/main/default/lwc/viewContactRecord/__tests__/viewContactRecord.test.js
+++ b/force-app/main/default/lwc/viewContactRecord/__tests__/viewContactRecord.test.js
@@ -55,6 +55,7 @@ describe("c-view-contact-record", () => {
 
     // check draft list
     const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
-    expect(draftEdits).not.toBeNull();
+    // Uncomment if using the c-draft-details-list component
+    // expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewContactRecord/__tests__/viewContactRecord.test.js
+++ b/force-app/main/default/lwc/viewContactRecord/__tests__/viewContactRecord.test.js
@@ -54,8 +54,8 @@ describe("c-view-contact-record", () => {
     ]);
 
     // check draft list
-    const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
     // Uncomment if using the c-draft-details-list component
+    // const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
     // expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewContactRecord/viewContactRecord.html
+++ b/force-app/main/default/lwc/viewContactRecord/viewContactRecord.html
@@ -15,7 +15,7 @@
                 </div>
 
                 <!-- show any draft information for this record -->
-                <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list>
+                <!-- <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list> -->
             </div>
         </template>
     </div>

--- a/force-app/main/default/lwc/viewOpportunityRecord/__tests__/viewOpportunityRecord.test.js
+++ b/force-app/main/default/lwc/viewOpportunityRecord/__tests__/viewOpportunityRecord.test.js
@@ -50,8 +50,8 @@ describe("c-view-opportunity-record", () => {
     ]);
 
     // check draft list
-    const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
     // Uncomment if using the c-draft-details-list component
+    // const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
     // expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewOpportunityRecord/__tests__/viewOpportunityRecord.test.js
+++ b/force-app/main/default/lwc/viewOpportunityRecord/__tests__/viewOpportunityRecord.test.js
@@ -51,6 +51,7 @@ describe("c-view-opportunity-record", () => {
 
     // check draft list
     const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
-    expect(draftEdits).not.toBeNull();
+    // Uncomment if using the c-draft-details-list component
+    // expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.html
+++ b/force-app/main/default/lwc/viewOpportunityRecord/viewOpportunityRecord.html
@@ -15,7 +15,7 @@
                 </div>
 
                 <!-- show any draft information for this record -->
-                <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list>
+                <!-- <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list> -->
             </div>
         </template>
     </div>

--- a/force-app/main/default/lwc/viewProduct2Record/__tests__/viewProduct2Record.test.js
+++ b/force-app/main/default/lwc/viewProduct2Record/__tests__/viewProduct2Record.test.js
@@ -51,8 +51,8 @@ describe("c-view-product2-record", () => {
     ]);
 
     // check draft list
-    const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
     // Uncomment if using the c-draft-details-list component
+    // const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
     // expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewProduct2Record/__tests__/viewProduct2Record.test.js
+++ b/force-app/main/default/lwc/viewProduct2Record/__tests__/viewProduct2Record.test.js
@@ -52,6 +52,7 @@ describe("c-view-product2-record", () => {
 
     // check draft list
     const draftEdits = element.shadowRoot.querySelector("c-draft-details-list");
-    expect(draftEdits).not.toBeNull();
+    // Uncomment if using the c-draft-details-list component
+    // expect(draftEdits).not.toBeNull();
   });
 });

--- a/force-app/main/default/lwc/viewProduct2Record/viewProduct2Record.html
+++ b/force-app/main/default/lwc/viewProduct2Record/viewProduct2Record.html
@@ -17,7 +17,7 @@
                 </div>
 
                 <!-- show any draft information for this record -->
-                <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list>
+                <!-- <c-draft-details-list record-id={recordId} fields={fields}></c-draft-details-list> -->
             </div>
         </template>
     </div>


### PR DESCRIPTION
This component is only recommended for debug purposes. It will negatively affect priming and load times. Commenting out to ensure it does not leak into production.