### PR TITLE
Prefetch file metadata in fileUpload lwc

### DIFF
--- a/force-app/main/default/lwc/fileUpload/__tests__/fileUpload.test.js
+++ b/force-app/main/default/lwc/fileUpload/__tests__/fileUpload.test.js
@@ -1,0 +1,53 @@
+import { createElement } from "lwc";
+import FileUpload from "c/fileUpload";
+
+describe("c-file-upload", () => {
+  afterEach(() => {
+    // The jsdom instance is shared across test cases in a single file, so, reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+
+    jest.clearAllMocks();
+  });
+
+  it("should show select files button", async () => {
+    // setup
+    const element = createElement("c-file-upload", {
+      is: FileUpload,
+    });
+    document.body.appendChild(element);
+
+    // test
+    // verify select files button is shown
+    const selectButton = element.shadowRoot.querySelector("lightning-input");
+    expect(selectButton.label).toBe("Pick file to upload");
+    // verify upload button is not shown
+    const uploadButton = element.shadowRoot.querySelector("button.slds-button");
+    expect(uploadButton).toBeNull();
+  });
+
+  it("should show upload button upon selecting files", async () => {
+    // setup
+    const element = createElement("c-file-upload", {
+      is: FileUpload,
+    });
+    document.body.appendChild(element);
+
+    // mock the change event on file button
+    const event = new CustomEvent("change", {
+      detail: { files: [{ name: "file.jpg" }] },
+    });
+    element.shadowRoot.querySelector("lightning-input").dispatchEvent(event);
+    // Resolve a promise to wait for a re-render of the new content
+    await Promise.resolve();
+
+    // test
+    // verify upload button is shown
+    const uploadButton = element.shadowRoot.querySelector("button.slds-button");
+    expect(uploadButton).not.toBeNull();
+    // verify file name is shown correctly
+    const title = element.shadowRoot.querySelectorAll("p")[1];
+    expect(title.textContent).toBe("file.jpg");
+  });
+});

--- a/force-app/main/default/lwc/fileUpload/fileUpload.js
+++ b/force-app/main/default/lwc/fileUpload/fileUpload.js
@@ -1,9 +1,13 @@
-import { LightningElement, api, track } from "lwc";
+import { LightningElement, api, wire, track } from "lwc";
 import {
   unstable_createContentDocumentAndVersion,
   createRecord,
 } from "lightning/uiRecordApi";
+import { getObjectInfos } from "lightning/uiObjectInfoApi";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
+import CONTENT_DOCUMENT_LINK from "@salesforce/schema/ContentDocumentLink";
+import CONTENT_DOCUMENT from "@salesforce/schema/ContentDocument";
+import CONTENT_VERSION from "@salesforce/schema/ContentVersion";
 
 export default class FileUpload extends LightningElement {
   @api
@@ -23,6 +27,11 @@ export default class FileUpload extends LightningElement {
 
   @track
   errorMessage = "";
+
+  @wire(getObjectInfos, {
+    objectApiNames: [CONTENT_DOCUMENT_LINK, CONTENT_DOCUMENT, CONTENT_VERSION],
+  })
+  objectMetadata;
 
   // This getter is only used for local processing. It does not need to be enabled for offline caching.
   // eslint-disable-next-line @salesforce/lwc-graph-analyzer/no-getter-contains-more-than-return-statement

--- a/force-app/main/default/lwc/fileUpload/fileUpload.js
+++ b/force-app/main/default/lwc/fileUpload/fileUpload.js
@@ -28,6 +28,7 @@ export default class FileUpload extends LightningElement {
   @track
   errorMessage = "";
 
+  // Object metadata are required for creating records in offline. The wire adapter is added here to ensure the content metadata are primed.
   @wire(getObjectInfos, {
     objectApiNames: [CONTENT_DOCUMENT_LINK, CONTENT_DOCUMENT, CONTENT_VERSION],
   })

--- a/force-app/main/default/lwc/fileUpload/fileUpload.js-meta.xml
+++ b/force-app/main/default/lwc/fileUpload/fileUpload.js-meta.xml
@@ -1,5 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>57.0</apiVersion>
-    <isExposed>false</isExposed>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__RecordAction</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordAction">
+            <actionType>ScreenAction</actionType>
+        </targetConfig>
+    </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
The fileUpload component creates content records when uploading files. Metadata needs to be prefetched for creating content records in offline. Without file metadata, user gets the error "Draft error 400, Cannot determine target id from the resource request". 