### PR TITLE
Using getter to remove lint warnings.

### DIFF
--- a/force-app/main/default/lwc/createAccountRecord/createAccountRecord.html
+++ b/force-app/main/default/lwc/createAccountRecord/createAccountRecord.html
@@ -25,11 +25,11 @@
                 <lightning-messages></lightning-messages>
 
                 <!-- input fields -->
-                <lightning-input-field field-name={nameField} value={name}></lightning-input-field>
-                <lightning-input-field field-name={phoneField} value={phone}></lightning-input-field>
-                <lightning-input-field field-name={websiteField} value={website}></lightning-input-field>
-                <lightning-input-field field-name={industryField} value={industry}></lightning-input-field>
-                <lightning-input-field field-name={typeField} value={type}></lightning-input-field>
+                <lightning-input-field field-name={nameField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={phoneField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={websiteField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={industryField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={typeField} value={initialValue}></lightning-input-field>
 
             </div>
 

--- a/force-app/main/default/lwc/createAccountRecord/createAccountRecord.js
+++ b/force-app/main/default/lwc/createAccountRecord/createAccountRecord.js
@@ -10,17 +10,29 @@ export default class CreateAccountRecord extends LightningElement {
   @api recordId;
   @api objectApiName;
 
-  nameField = NAME_FIELD;
-  phoneField = PHONE_FIELD;
-  websiteField = WEBSITE_FIELD;
-  industryField = INDUSTRY_FIELD;
-  typeField = TYPE_FIELD;
+  get nameField() {
+    return NAME_FIELD;
+  }
 
-  name = "";
-  phone = "";
-  website = "";
-  industry = "";
-  type = "";
+  get phoneField() {
+    return PHONE_FIELD;
+  }
+
+  get websiteField() {
+    return WEBSITE_FIELD;
+  }
+
+  get industryField() {
+    return INDUSTRY_FIELD;
+  }
+
+  get typeField() {
+    return TYPE_FIELD;
+  }
+
+  get initialValue() {
+    return "";
+  }
 
   onSuccess(event) {
     console.log("Created account", event.detail);

--- a/force-app/main/default/lwc/createContactRecord/createContactRecord.html
+++ b/force-app/main/default/lwc/createContactRecord/createContactRecord.html
@@ -20,11 +20,11 @@
             <lightning-messages></lightning-messages>
 
             <!-- input fields -->
-            <lightning-input-field field-name={nameField} value={name}></lightning-input-field>
-            <lightning-input-field field-name={titleField} value={title}></lightning-input-field>
-            <lightning-input-field field-name={phoneField} value={phone}></lightning-input-field>
-            <lightning-input-field field-name={emailField} value={email}></lightning-input-field>
-            <lightning-input-field field-name={mobileField} value={mobile}></lightning-input-field>
+            <lightning-input-field field-name={nameField} value={initialValue}></lightning-input-field>
+            <lightning-input-field field-name={titleField} value={initialValue}></lightning-input-field>
+            <lightning-input-field field-name={phoneField} value={initialValue}></lightning-input-field>
+            <lightning-input-field field-name={emailField} value={initialValue}></lightning-input-field>
+            <lightning-input-field field-name={mobileField} value={initialValue}></lightning-input-field>
             <lightning-input-field field-name={ownerField}></lightning-input-field>
 
             <!-- 
@@ -36,7 +36,7 @@
                 label="Account"
                 placeholder="Search Accounts..."
                 object-api-name="Account"
-                value={account}
+                value={initialValue}
                 onchange={handleChange}
             >
             </lightning-record-picker>

--- a/force-app/main/default/lwc/createContactRecord/createContactRecord.js
+++ b/force-app/main/default/lwc/createContactRecord/createContactRecord.js
@@ -1,7 +1,6 @@
 import { LightningElement, api } from "lwc";
 import CONTACT_NAME_FIELD from "@salesforce/schema/Contact.Name";
 import CONTACT_TITLE_FIELD from "@salesforce/schema/Contact.Title";
-import CONTACT_ACCOUNT_FIELD from "@salesforce/schema/Contact.AccountId";
 import CONTACT_PHONE_FIELD from "@salesforce/schema/Contact.Phone";
 import CONTACT_EMAIL_FIELD from "@salesforce/schema/Contact.Email";
 import CONTACT_MOBILE_FIELD from "@salesforce/schema/Contact.MobilePhone";
@@ -11,20 +10,32 @@ export default class CreateContactRecord extends LightningElement {
   @api recordId;
   @api objectApiName;
 
-  nameField = CONTACT_NAME_FIELD;
-  titleField = CONTACT_TITLE_FIELD;
-  accountField = CONTACT_ACCOUNT_FIELD;
-  phoneField = CONTACT_PHONE_FIELD;
-  emailField = CONTACT_EMAIL_FIELD;
-  mobileField = CONTACT_MOBILE_FIELD;
-  ownerField = CONTACT_OWNER_FIELD;
+  get nameField() {
+    return CONTACT_NAME_FIELD;
+  }
+  get titleField() {
+    return CONTACT_TITLE_FIELD;
+  }
 
-  name = "";
-  title = "";
-  account = "";
-  phone = "";
-  email = "";
-  mobile = "";
+  get phoneField() {
+    return CONTACT_PHONE_FIELD;
+  }
+
+  get emailField() {
+    return CONTACT_EMAIL_FIELD;
+  }
+
+  get mobileField() {
+    return CONTACT_MOBILE_FIELD;
+  }
+
+  get ownerField() {
+    return CONTACT_OWNER_FIELD;
+  }
+
+  get initialValue() {
+    return "";
+  }
 
   selectedId;
 

--- a/force-app/main/default/lwc/createOpportunityRecord/createOpportunityRecord.html
+++ b/force-app/main/default/lwc/createOpportunityRecord/createOpportunityRecord.html
@@ -23,11 +23,11 @@
                 <lightning-messages></lightning-messages>
               
                 <!-- input fields -->
-                <lightning-input-field field-name={nameField} value={name}></lightning-input-field>
-                <lightning-input-field field-name={accountField} value={account}></lightning-input-field>
-                <lightning-input-field field-name={closeDateField} value={closeDate}></lightning-input-field>
-                <lightning-input-field field-name={amountField} value={amount}></lightning-input-field>
-                <lightning-input-field field-name={stageNameField} value={stageName}></lightning-input-field>
+                <lightning-input-field field-name={nameField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={accountField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={closeDateField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={amountField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={stageNameField} value={initialValue}></lightning-input-field>
                 <lightning-input-field field-name={ownerField}></lightning-input-field>
 
             </div>

--- a/force-app/main/default/lwc/createOpportunityRecord/createOpportunityRecord.js
+++ b/force-app/main/default/lwc/createOpportunityRecord/createOpportunityRecord.js
@@ -10,18 +10,33 @@ export default class CreateContactRecord extends LightningElement {
   @api recordId;
   @api objectApiName;
 
-  nameField = OPPORTUNITY_NAME_FIELD;
-  accountField = OPPORTUNITY_ACCOUNT_FIELD;
-  closeDateField = OPPORTUNITY_CLOSE_DATE_FIELD;
-  amountField = OPPORTUNITY_AMOUNT_FIELD;
-  stageNameField = OPPORTUNITY_STAGENAME_FIELD;
-  ownerField = OPPORTUNITY_OWNER_FIELD;
+  get nameField() {
+    return OPPORTUNITY_NAME_FIELD;
+  }
 
-  name = "";
-  account = "";
-  closeDate = "";
-  amount = "";
-  stageName = "";
+  get accountField() {
+    return OPPORTUNITY_ACCOUNT_FIELD;
+  }
+
+  get closeDateField() {
+    return OPPORTUNITY_CLOSE_DATE_FIELD;
+  }
+
+  get amountField() {
+    return OPPORTUNITY_AMOUNT_FIELD;
+  }
+
+  get stageNameField() {
+    return OPPORTUNITY_STAGENAME_FIELD;
+  }
+
+  get ownerField() {
+    return OPPORTUNITY_OWNER_FIELD;
+  }
+
+  get initialValue() {
+    return "";
+  }
 
   onSuccess(event) {
     console.log("Created opportunity", event.detail);

--- a/force-app/main/default/lwc/createStarterKitCustomObjectRecord/createStarterKitCustomObjectRecord.html
+++ b/force-app/main/default/lwc/createStarterKitCustomObjectRecord/createStarterKitCustomObjectRecord.html
@@ -25,12 +25,12 @@
                 <lightning-messages></lightning-messages>
 
                 <!-- input fields -->
-                <lightning-input-field field-name={nameField} value={name}></lightning-input-field>
-                <lightning-input-field field-name={start_Time__cField} value={start_Time__c}></lightning-input-field>
-                <lightning-input-field field-name={end_Time__cField} value={end_Time__c}></lightning-input-field>
-                <lightning-input-field field-name={priority__cField} value={priority__c}></lightning-input-field>
-                <lightning-input-field field-name={status__cField} value={status__c}></lightning-input-field>
-                <lightning-input-field field-name={address__cField} value={address__c}></lightning-input-field>
+                <lightning-input-field field-name={nameField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={start_Time__cField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={end_Time__cField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={priority__cField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={status__cField} value={initialValue}></lightning-input-field>
+                <lightning-input-field field-name={address__cField} value={initialValue}></lightning-input-field>
             </div>
 
         </lightning-record-edit-form>

--- a/force-app/main/default/lwc/createStarterKitCustomObjectRecord/createStarterKitCustomObjectRecord.js
+++ b/force-app/main/default/lwc/createStarterKitCustomObjectRecord/createStarterKitCustomObjectRecord.js
@@ -11,19 +11,33 @@ export default class CreateStarterKitCustomObject__cRecord extends LightningElem
   @api recordId;
   @api objectApiName;
 
-  nameField = NAME_FIELD;
-  start_Time__cField = START_TIME__C_FIELD;
-  end_Time__cField = END_TIME__C_FIELD;
-  priority__cField = PRIORITY__C_FIELD;
-  status__cField = STATUS__C_FIELD;
-  address__cField = ADDRESS__C_FIELD;
+  get nameField() {
+    return NAME_FIELD;
+  }
 
-  name = "";
-  start_Time__c = "";
-  end_Time__c = "";
-  priority__c = "";
-  status__c = "";
-  address__c = "";
+  get start_Time__cField() {
+    return START_TIME__C_FIELD;
+  }
+
+  get end_Time__cField() {
+    return END_TIME__C_FIELD;
+  }
+
+  get priority__cField() {
+    return PRIORITY__C_FIELD;
+  }
+
+  get status__cField() {
+    return STATUS__C_FIELD;
+  }
+
+  get address__cField() {
+    return ADDRESS__C_FIELD;
+  }
+
+  get initialValue() {
+    return "";
+  }
 
   onSuccess(event) {
     console.log("Created StarterKitCustomObject__c", event.detail);

--- a/force-app/main/default/lwc/editAccountRecord/editAccountRecord.js
+++ b/force-app/main/default/lwc/editAccountRecord/editAccountRecord.js
@@ -11,11 +11,25 @@ export default class EditAccountRecord extends LightningElement {
   @api recordId;
   @api objectApiName;
 
-  nameField = NAME_FIELD;
-  phoneField = PHONE_FIELD;
-  websiteField = WEBSITE_FIELD;
-  industryField = INDUSTRY_FIELD;
-  typeField = TYPE_FIELD;
+  get nameField() {
+    return NAME_FIELD;
+  }
+
+  get phoneField() {
+    return PHONE_FIELD;
+  }
+
+  get websiteField() {
+    return WEBSITE_FIELD;
+  }
+
+  get industryField() {
+    return INDUSTRY_FIELD;
+  }
+
+  get typeField() {
+    return TYPE_FIELD;
+  }
 
   @wire(getRecord, { recordId: "$recordId", fields: [NAME_FIELD] })
   record;

--- a/force-app/main/default/lwc/editContactRecord/editContactRecord.js
+++ b/force-app/main/default/lwc/editContactRecord/editContactRecord.js
@@ -12,12 +12,29 @@ export default class EditContactRecord extends LightningElement {
   @api recordId;
   @api objectApiName;
 
-  nameField = CONTACT_NAME_FIELD;
-  titleField = CONTACT_TITLE_FIELD;
-  accountField = CONTACT_ACCOUNT_FIELD;
-  phoneField = CONTACT_PHONE_FIELD;
-  emailField = CONTACT_EMAIL_FIELD;
-  mobileField = CONTACT_MOBILE_FIELD;
+  get nameField() {
+    return CONTACT_NAME_FIELD;
+  }
+
+  get titleField() {
+    return CONTACT_TITLE_FIELD;
+  }
+
+  get accountField() {
+    return CONTACT_ACCOUNT_FIELD;
+  }
+
+  get phoneField() {
+    return CONTACT_PHONE_FIELD;
+  }
+
+  get emailField() {
+    return CONTACT_EMAIL_FIELD;
+  }
+
+  get mobileField() {
+    return CONTACT_MOBILE_FIELD;
+  }
 
   @wire(getRecord, { recordId: "$recordId", fields: [CONTACT_NAME_FIELD] })
   record;

--- a/force-app/main/default/lwc/editOpportunityRecord/editOpportunityRecord.js
+++ b/force-app/main/default/lwc/editOpportunityRecord/editOpportunityRecord.js
@@ -11,11 +11,25 @@ export default class EditOpportunityRecord extends LightningElement {
   @api recordId;
   @api objectApiName;
 
-  nameField = OPPORTUNITY_NAME_FIELD;
-  accountField = OPPORTUNITY_ACCOUNT_FIELD;
-  closeDateField = OPPORTUNITY_CLOSE_DATE_FIELD;
-  amountField = OPPORTUNITY_AMOUNT_FIELD;
-  stageNameField = OPPORTUNITY_STAGENAME_FIELD;
+  get nameField() {
+    return OPPORTUNITY_NAME_FIELD;
+  }
+
+  get accountField() {
+    return OPPORTUNITY_ACCOUNT_FIELD;
+  }
+
+  get closeDateField() {
+    return OPPORTUNITY_CLOSE_DATE_FIELD;
+  }
+
+  get amountField() {
+    return OPPORTUNITY_AMOUNT_FIELD;
+  }
+
+  get stageNameField() {
+    return OPPORTUNITY_STAGENAME_FIELD;
+  }
 
   @wire(getRecord, { recordId: "$recordId", fields: [OPPORTUNITY_NAME_FIELD] })
   record;

--- a/force-app/main/default/lwc/editStarterKitCustomObjectRecord/editStarterKitCustomObjectRecord.html
+++ b/force-app/main/default/lwc/editStarterKitCustomObjectRecord/editStarterKitCustomObjectRecord.html
@@ -31,7 +31,9 @@
                 <lightning-input-field field-name={end_Time__cField}></lightning-input-field>
                 <lightning-input-field field-name={priority__cField}></lightning-input-field>
                 <lightning-input-field field-name={status__cField}></lightning-input-field>
-                <lightning-input-field field-name={address__cField}></lightning-input-field>            </div>
+                <lightning-input-field field-name={address__cField}></lightning-input-field>
+                
+            </div>
 
         </lightning-record-edit-form>
     </div>

--- a/force-app/main/default/lwc/editStarterKitCustomObjectRecord/editStarterKitCustomObjectRecord.js
+++ b/force-app/main/default/lwc/editStarterKitCustomObjectRecord/editStarterKitCustomObjectRecord.js
@@ -12,12 +12,29 @@ export default class EditStarterKitCustomObject__cRecord extends LightningElemen
   @api recordId;
   @api objectApiName;
 
-  nameField = NAME_FIELD;
-  start_Time__cField = START_TIME__C_FIELD;
-  end_Time__cField = END_TIME__C_FIELD;
-  priority__cField = PRIORITY__C_FIELD;
-  status__cField = STATUS__C_FIELD;
-  address__cField = ADDRESS__C_FIELD;
+  get nameField() {
+    return NAME_FIELD;
+  }
+
+  get start_Time__cField() {
+    return START_TIME__C_FIELD;
+  }
+
+  get end_Time__cField() {
+    return END_TIME__C_FIELD;
+  }
+
+  get priority__cField() {
+    return PRIORITY__C_FIELD;
+  }
+
+  get status__cField() {
+    return STATUS__C_FIELD;
+  }
+
+  get address__cField() {
+    return ADDRESS__C_FIELD;
+  }
 
   @wire(getRecord, { recordId: "$recordId", fields: [NAME_FIELD] })
   record;


### PR DESCRIPTION
Read only constants can be wrapped inside getters to avoid lint warnings.

Consolidated empty string initial values.