### PR TITLE
Update adapter name for createContentDocumentAndVersion

### DIFF
--- a/force-app/main/default/lwc/fileUpload/fileUpload.js
+++ b/force-app/main/default/lwc/fileUpload/fileUpload.js
@@ -1,6 +1,6 @@
 import { LightningElement, api, wire, track } from "lwc";
 import {
-  unstable_createContentDocumentAndVersion,
+  createContentDocumentAndVersion,
   createRecord,
 } from "lightning/uiRecordApi";
 import { getObjectInfos } from "lightning/uiObjectInfoApi";
@@ -82,12 +82,11 @@ export default class FileUpload extends LightningElement {
 
       // Create a Content Document and Version for the file
       // effectively uploading it
-      const contentDocumentAndVersion =
-        await unstable_createContentDocumentAndVersion({
-          title: this.titleValue,
-          description: this.descriptionValue,
-          fileData: file,
-        });
+      const contentDocumentAndVersion = await createContentDocumentAndVersion({
+        title: this.titleValue,
+        description: this.descriptionValue,
+        fileData: file,
+      });
 
       if (this.recordId) {
         const contentDocumentId = contentDocumentAndVersion.contentDocument.id;


### PR DESCRIPTION
The adapter unstable_createContentDocumentAndVersion is replaced by createContentDocumentAndVersion, as shown in [this doc](https://developer.salesforce.com/docs/atlas.en-us.mobile_offline.meta/mobile_offline/use_images_upload_while_offline_example.htm).

