### PR TITLE
Use single return statement in graphql getters

### DIFF
--- a/docs/RelatedRecords.md
+++ b/docs/RelatedRecords.md
@@ -12,25 +12,29 @@ In this example, we perform a GraphQL query to fetch related `Contacts` from an 
 
 ```js
   get accountQuery() {
-    return gql`
-      query accountWithChildContacts($recordId: ID) {
-        uiapi {
-          query {
-            Account(where: { Id: { eq: $recordId } }) {
-              edges {
-                node {
-                  Contacts {
-                    edges {
-                      node {
-                        Id
-                        Name {
-                          value
-                        }
-                        Phone {
-                          value
-                        }
-                        Email {
-                          value
+    return !this.recordId
+      ? undefined
+      : gql`
+          query accountWithChildContacts($recordId: ID) {
+            uiapi {
+              query {
+                Account(where: { Id: { eq: $recordId } }) {
+                  edges {
+                    node {
+                      Contacts {
+                        edges {
+                          node {
+                            Id
+                            Name {
+                              value
+                            }
+                            Phone {
+                              value
+                            }
+                            Email {
+                              value
+                            }
+                          }
                         }
                       }
                     }
@@ -39,9 +43,7 @@ In this example, we perform a GraphQL query to fetch related `Contacts` from an 
               }
             }
           }
-        }
-      }
-    `;
+        `;
   }
 ```
 

--- a/force-app/main/default/lwc/accountRelatedContacts/accountRelatedContacts.js
+++ b/force-app/main/default/lwc/accountRelatedContacts/accountRelatedContacts.js
@@ -1,6 +1,5 @@
 import { LightningElement, api, wire } from "lwc";
 import { NavigationMixin } from "lightning/navigation";
-
 import { graphql, gql } from "lightning/uiGraphQLApi";
 
 // eslint-disable-next-line @salesforce/lwc-graph-analyzer/no-unresolved-parent-class-reference
@@ -15,25 +14,29 @@ export default class AccountRelatedContacts extends NavigationMixin(
     As of Spring '24 release the issue has been addressed.
   */
   get accountQuery() {
-    return gql`
-      query accountWithChildContacts($recordId: ID) {
-        uiapi {
-          query {
-            Account(where: { Id: { eq: $recordId } }) {
-              edges {
-                node {
-                  Contacts {
-                    edges {
-                      node {
-                        Id
-                        Name {
-                          value
-                        }
-                        Phone {
-                          value
-                        }
-                        Email {
-                          value
+    return !this.recordId
+      ? undefined
+      : gql`
+          query accountWithChildContacts($recordId: ID) {
+            uiapi {
+              query {
+                Account(where: { Id: { eq: $recordId } }) {
+                  edges {
+                    node {
+                      Contacts {
+                        edges {
+                          node {
+                            Id
+                            Name {
+                              value
+                            }
+                            Phone {
+                              value
+                            }
+                            Email {
+                              value
+                            }
+                          }
                         }
                       }
                     }
@@ -42,9 +45,7 @@ export default class AccountRelatedContacts extends NavigationMixin(
               }
             }
           }
-        }
-      }
-    `;
+        `;
   }
 
   // https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_graphql_relationships
@@ -66,7 +67,7 @@ export default class AccountRelatedContacts extends NavigationMixin(
 
   get graphqlVariables() {
     return {
-      recordId: this.recordId || "",
+      recordId: this.recordId,
     };
   }
 

--- a/force-app/main/default/lwc/scanBarcodeLookup/scanBarcodeLookup.js
+++ b/force-app/main/default/lwc/scanBarcodeLookup/scanBarcodeLookup.js
@@ -40,26 +40,26 @@ export default class ScanBarcodeLookup extends LightningElement {
   }
 
   get productQuery() {
-    if (!this.scannedBarcode) return undefined;
-
-    return gql`
-      query productBarcodeLookup($upc: String) {
-        uiapi {
-          query {
-            Product2(where: { ProductCode: { eq: $upc } }) {
-              edges {
-                node {
-                  Id
-                  Name {
-                    value
+    return !this.scannedBarcode
+      ? undefined
+      : gql`
+          query productBarcodeLookup($upc: String) {
+            uiapi {
+              query {
+                Product2(where: { ProductCode: { eq: $upc } }) {
+                  edges {
+                    node {
+                      Id
+                      Name {
+                        value
+                      }
+                    }
                   }
                 }
               }
             }
           }
-        }
-      }
-    `;
+        `;
   }
 
   get graphqlVariables() {


### PR DESCRIPTION
The reasons to use single return statement in getters are:
- It supports mobile prefetching in the wire adapter who uses the getters. Otherwise, the static analyzer shows the warning.
- Returning _undefined_ from the graphql getter is recommended when the query parameter is not available, as explained in [Delay Query Execution](https://developer.salesforce.com/docs/platform/graphql/guide/graphql-wire-lwc-best.html#delay-query-execution).  