### PR TITLE
ci: upgrade github actions to latest version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,8 @@ jobs:
         node: [ 20 ]
     name: Linting on Ubuntu with Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -9,8 +9,8 @@ jobs:
         node: [ 20 ]
     name: Prettier on Ubuntu with Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,8 @@ jobs:
         node: [ 20, 22 ]
     name: Tests on Ubuntu with Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'
@@ -23,8 +23,8 @@ jobs:
         node: [ 20, 22 ]
     name: Tests on Windows with Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'


### PR DESCRIPTION
Upgrade github actions to latest version.

The `@v3` version of the github actions rely on Node 16. GitHub had previously announced that everyone should upgrade their actions to move to Node 20.